### PR TITLE
feat: hot update

### DIFF
--- a/conf/rulex.ini
+++ b/conf/rulex.ini
@@ -58,6 +58,8 @@ gomax_procs = 0
 # 'http://0.0.0.0:6060'
 #
 enable_pprof = false
+
+update_server = http://localhost:8088/rulex
 #-----------------------------------------------------
 # Buildin Plugins Config
 #-----------------------------------------------------

--- a/engine/updater.go
+++ b/engine/updater.go
@@ -1,0 +1,280 @@
+package engine
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/hootrhino/rulex/glogger"
+)
+
+/**
+GET /rulex?version=v1.5xx&arch=amd64&os=linux
+Response:
+headers=[
+	'Rulex-Md5': 'xxx'
+	'Rulex-Version':'v1.6'
+]
+body=exec_file
+
+*/
+
+// checkForUpdates rulex热更新，应当在单独的线程执行
+func (e *RuleEngine) checkForUpdates(sig chan<- string) {
+	// 设置轮询检查更新的定时器
+	var t = time.NewTicker(10 * time.Minute)
+	// 定时检查新版本
+	for range t.C {
+		glogger.GLogger.Info("checking for updates")
+		data, err := requsetNewVerion(e.Config.UpdateServer)
+		if err != nil {
+			glogger.GLogger.Errorf("request new version failed, %s", err.Error())
+			continue
+		}
+		if err = writeToFile(newRulex, data); err != nil {
+			glogger.GLogger.Errorf("writeToFile: %s", err.Error())
+			continue
+		}
+
+		sig <- newRulex
+	}
+}
+
+const newRulex = "./rulex_new"
+
+func requsetNewVerion(version string) ([]byte, error) {
+	// 构建请求
+	req, err := http.NewRequest(http.MethodGet, version, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.RawQuery = fmt.Sprintf("arch=%s&os=%s&version=%s",
+		runtime.GOARCH, runtime.GOOS, version)
+	cli := http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := cli.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("response: %s", resp.Status)
+	}
+	newVersion := resp.Header.Get("Rulex-Version")
+	md5Str := resp.Header.Get("Rulex-Md5")
+	if len(newVersion) == 0 || len(md5Str) == 0 {
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
+		return nil, fmt.Errorf("response: version='%s', md5='%s'", newVersion, md5Str)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	md5Data := md5.Sum(data)
+	md5Str1 := hex.EncodeToString(md5Data[:])
+	if md5Str != md5Str1 {
+		return nil, fmt.Errorf("response: inconsistent MD5, '%s'!='%s'", md5Str, md5Str1)
+	}
+
+	glogger.GLogger.Infof("received new version '%s'", version)
+	return data, nil
+}
+
+func writeToFile(fileName string, data []byte) error {
+	info, err := os.Stat(fileName)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if info != nil && !info.IsDir() {
+		os.Remove(info.Name())
+	}
+	file, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if _, err = file.Write(data); err != nil {
+		return err
+	}
+
+	return file.Chmod(0777)
+}
+
+// update 执行更新流程
+func update(e *RuleEngine, name string) bool {
+	fmt.Println("rulex updating")
+
+	e.Version()
+	// 1. 关闭当前服务
+	e.Stop()
+
+	// 2. 开启新服务
+	var proc = Process{
+		Name: name,
+		Env:  true,
+		Argv: os.Args,
+	}
+	pid, err := proc.Start()
+	// 3. 更新失败，重新启动服务
+	if err != nil {
+		fmt.Printf("update failed, error is '%s'\n", err.Error())
+		e.Start()
+		return false
+	}
+
+	fmt.Printf("update succeed, new process is '%d'\n", pid)
+	return true
+}
+
+// Wait 阻塞当前进程，等待关闭信号
+func (e *RuleEngine) Wait(signals ...os.Signal) {
+	sigs := make(chan os.Signal, 10)
+	signal.Notify(sigs, signals...)
+
+	var updateSig chan string
+	fmt.Println("wait", e.Config.UpdateServer, e.Config.LogPath)
+	if len(e.Config.UpdateServer) > 0 {
+		updateSig = make(chan string, 1)
+		go e.checkForUpdates(updateSig)
+	}
+
+	//	读取信号
+	for {
+		select {
+		case <-sigs: //关闭信号，直接退出
+			e.Stop()
+			return
+		case name := <-updateSig: // 检查更新
+			// 更新成功，直接退出
+			if update(e, name) {
+				return
+			}
+		}
+	}
+}
+
+// / Process 进程参数
+type Process struct {
+	Name       string         // 要加载的可执行文件路径
+	Listener   []net.Listener // 要继承的链接
+	Env        bool           // 是否继承环境变量?
+	ExcludeEnv []string       // 要忽略的环境变量key
+	Argv       []string       // 传递给新进程的命令行参数
+}
+
+// Filer 获取 os.File
+type Filer interface {
+	File() (f *os.File, err error)
+}
+
+// environ 继承环境变量
+func (p Process) environ() []string {
+	if !p.Env {
+		return nil
+	}
+
+	var envs = os.Environ()
+	var excludeEnv = append(p.ExcludeEnv, rulexInheritedFd)
+	var envList = make([]string, 0, len(envs)+2)
+	for _, s := range envs {
+		var exclude bool
+		for _, prefix := range excludeEnv {
+			if len(s) > len(prefix) && s[len(prefix)] == '=' &&
+				s[0:len(prefix)] == prefix {
+				exclude = true
+				break
+			}
+		}
+		if exclude {
+			continue
+		}
+		envList = append(envList, s)
+	}
+
+	return envList
+}
+
+func (p Process) files() []*os.File {
+	var files = make([]*os.File, 0, len(p.Listener)+minInheritedFdCount)
+	files = append(files, os.Stdin, os.Stdout, os.Stderr)
+
+	// 从lisnter 转为 os.File
+	for _, ln := range p.Listener {
+		filer, ok := ln.(Filer)
+		if !ok {
+			continue
+		}
+
+		// 获取到文件描述符
+		file, err := filer.File()
+		if err != nil {
+			continue
+		}
+		files = append(files, file)
+	}
+
+	return files
+}
+
+const (
+	rulexInherited      = "RULEX_INHERITED"
+	rulexInheritedFd    = "RULEX_INHERITED_FD"
+	minInheritedFdCount = 3
+)
+
+// Start 启动新的进程
+func (p Process) Start() (int, error) {
+	// 查找可执行文件是否存在
+	file, err := exec.LookPath(p.Name)
+	if err != nil {
+		return -1, err
+	}
+
+	// 构建文件描述符列表
+	var files = p.files()
+	// File()函数会调用系统调用copy一份fd，这里要进行关闭
+	// 但是 stdin，stdout，stderr是直接引用的，不能关闭
+	defer func() {
+		for i := minInheritedFdCount; i < len(files); i++ {
+			fd := files[i]
+			_ = fd.Close()
+		}
+	}()
+
+	// 获取到，要继承的环境变量
+	env := p.environ()
+
+	// 将继承的，文件描述符的数量写入到env
+	if len(files) > minInheritedFdCount {
+		env = append(env, rulexInheritedFd+"="+strconv.Itoa(len(files)))
+	}
+
+	// 获取到当前的执行路径
+	wd, _ := os.Getwd()
+	// 构建参数
+	attr := os.ProcAttr{
+		Dir:   wd,
+		Env:   env,
+		Files: files,
+	}
+
+	// 启动新进程
+	proc, err := os.StartProcess(file, p.Argv, &attr)
+	if err != nil {
+		return -1, fmt.Errorf("start_process: %w", err)
+	}
+
+	return proc.Pid, nil
+}

--- a/engine/updatet_test.go
+++ b/engine/updatet_test.go
@@ -1,0 +1,59 @@
+package engine
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	fmt.Println(os.Args[0])
+	s := gin.Default()
+	s.GET("/rulex", downloadRulex)
+	// s.StaticFile("/rulex", "./rulex")
+	s.Run(":8088")
+}
+
+var (
+	supportedArch = Strings{"amd64", "arm64"}
+	supportedOS   = Strings{"linux", "windows"}
+)
+
+type Strings []string
+
+func (ss Strings) Has(s string) bool {
+	for i := range ss {
+		if ss[i] == s {
+			return true
+		}
+	}
+	return false
+}
+
+func downloadRulex(c *gin.Context) {
+	var (
+		os   = c.Query("os")
+		arch = c.Query("arch")
+		// version = c.Query("version")
+	)
+
+	// 检查参数
+	if !supportedArch.Has(arch) {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	if !supportedOS.Has(os) {
+		c.Status(http.StatusNotFound)
+		return
+	}
+
+	// TODO: 这里测试，暂时不检查version
+	// 当请求字段没有version时，当作latest（最新版本）处理
+	// 当version字段有效且大于等于最新版本时，不返回内容
+
+	c.Writer.Header().Add("Rulex-Version", "v1.5.x")
+	c.Writer.Header().Add("Rulex-MD5", "cc21c06617b95eabc812b82ffad2e9a8")
+	c.File("./rulex_new")
+}

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/pion/logging v0.2.2 // indirect
 	github.com/pion/transport/v2 v2.2.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/plgd-dev/kit/v2 v2.0.0-20211006190727-057b33161b90 // indirect
+	github.com/plgd-dev/kit/v2 v2.0.0-20211006190727-057b33161b90
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
 	github.com/prometheus/client_golang v1.4.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -669,7 +669,9 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/juju/errors v0.0.0-20170703010042-c7d06af17c68 h1:d2hBkTvi7B89+OXY8+bBBshPlc+7JYacGrG/dFak8SQ=
 github.com/juju/errors v0.0.0-20170703010042-c7d06af17c68/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
+github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 h1:UUHMLvzt/31azWTN/ifGWef4WUqvXk0iRqdhdy/2uzI=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
+github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b h1:Rrp0ByJXEjhREMPGTt3aWYjoIsUGCbt21ekbeJcTWv0=
 github.com/juju/testing v0.0.0-20191001232224-ce9dec17d28b/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
@@ -686,8 +688,8 @@ github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZY
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
@@ -1541,6 +1543,7 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 h1:VpOs+IwYnYBaFnrNAeB8UUWtL3vEUnzSCL1nVjPhqrw=
 gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/typex/rulex.go
+++ b/typex/rulex.go
@@ -2,6 +2,7 @@ package typex
 
 import (
 	"context"
+	"os"
 	"sync"
 )
 
@@ -23,6 +24,7 @@ type RulexConfig struct {
 	MaxStoreSize          int    `ini:"max_store_size" json:"maxStoreSize"`
 	AppDebugMode          bool   `ini:"app_debug_mode" json:"appDebugMode"`
 	Extlibs               Extlib `ini:"extlibs,,allowshadow" json:"extlibs"`
+	UpdateServer          string `ini:"update_server" json:"updateServer"`
 }
 
 // RuleX interface
@@ -133,6 +135,8 @@ type RuleX interface {
 	// 停止规则引擎
 	//
 	Stop()
+	// 优雅关闭
+	Wait(...os.Signal)
 	//
 	// Snapshot Dump
 	//


### PR DESCRIPTION
1. RuleEngine添加了Wait方法，用于替换信号监听逻辑，里面集成了升级实现
2. 配置upate_server地址后，会自动检查新版本并下载可执行文件，server的实现已在updater_test.go给出
3. 执行升级之前，会调用RuleEngine.Stop关闭当前服务，更新成功之后会直接退出，失败会调用Start()重启
4. 要注意重启过程中的状态一致性，已发现的问题有，Stop之后再Start，日志文件不会重新打开，导致异常